### PR TITLE
MANIFEST v3

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,6 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "default_locale": "en",
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "icons": {
     "16": "images/icons/16x16.png",
     "38": "images/icons/38x38.png",
@@ -38,7 +37,7 @@
       "run_at": "document_end"
     }
   ],
-  "browser_action": {
+  "action": {
     "default_title": "Boost",
     "default_popup": "popup/index.html?uilocation=popup",
     "browser_style": true,

--- a/utils/adjust_manifest.js
+++ b/utils/adjust_manifest.js
@@ -2,9 +2,6 @@ const env = require('./env');
 
 module.exports = (content) => {
   const manifest = JSON.parse(content);
-  if (env.NODE_ENV == 'production') {
-    delete manifest.content_security_policy;
-  }
 
   const name = process.env.npm_package_name.charAt(0).toUpperCase() +
                process.env.npm_package_name.slice(1);


### PR DESCRIPTION
this breaks the harvest integration with pivotal as the CSP doesn't allow to insert scripts from somewhere else (here https://platform.harvestapp.com)

Links:

- Migration guide: https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/
- Difference of CSP between v3 and v2: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy